### PR TITLE
Fix support for syncronous calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,8 +120,13 @@ ENS.prototype.resolver = function(name) {
     }
 
     var abi = resolverInterface;
-    if((callback && arguments.length == 4) || (!callback && arguments.length == 3))
-        resolverInterface = arguments[arguments.length - 2];
+
+    var params = {};
+    if (callback && arguments.length==4){
+        params = arguments[arguments.length-2];
+    } else if (!callback && arguments.length==2){
+        params = arguments[arguments.length-1];
+    }
 
     if(!callback) {
         result = this.registry.resolver(node);
@@ -164,8 +169,11 @@ ENS.prototype.setResolver = function(name, addr) {
     }
 
     var params = {};
-    if((callback && arguments.length == 4) || (!callback && arguments.length == 3))
-        params = arguments[arguments.length - 2];
+    if (callback && arguments.length==4){
+        params = arguments[arguments.length-2];
+    } else if (!callback && arguments.length==3){
+        params = arguments[arguments.length-1];
+    }
 
     if(!callback) {
         return this.registry.setResolver(node, addr, params);
@@ -211,8 +219,11 @@ ENS.prototype.setOwner = function(name, addr) {
     }
 
     var params = {};
-    if((callback && arguments.length == 4) || (!callback && arguments.length == 3))
-        params = arguments[arguments.length - 2];
+    if (callback && arguments.length==4){
+        params = arguments[arguments.length-2];
+    } else if (!callback && arguments.length==3){
+        params = arguments[arguments.length-1];
+    }
 
     if(!callback) {
         return this.registry.setOwner(node, addr, params);
@@ -242,8 +253,11 @@ ENS.prototype.setSubnodeOwner = function(name, addr) {
     }
 
     var params = {};
-    if((callback && arguments.length == 4) || (!callback && arguments.length == 3))
-        params = arguments[arguments.length - 2];
+    if (callback && arguments.length==4){
+        params = arguments[arguments.length-2];
+    } else if (!callback && arguments.length==3){
+        params = arguments[arguments.length-1];
+    }
 
     if(!callback) {
         return this.registry.setSubnodeOwner(node[1], node[0], addr, params);

--- a/index.js
+++ b/index.js
@@ -120,12 +120,10 @@ ENS.prototype.resolver = function(name) {
     }
 
     var abi = resolverInterface;
-
-    var params = {};
-    if (callback && arguments.length==4){
-        params = arguments[arguments.length-2];
-    } else if (!callback && arguments.length==2){
-        params = arguments[arguments.length-1];
+    if(callback && arguments.length == 3) {
+        abi = arguments[arguments.length - 2];
+    } else if(!callback && arguments.length == 2) {
+        abi = arguments[arguments.length - 1];
     }
 
     if(!callback) {
@@ -169,10 +167,10 @@ ENS.prototype.setResolver = function(name, addr) {
     }
 
     var params = {};
-    if (callback && arguments.length==4){
-        params = arguments[arguments.length-2];
-    } else if (!callback && arguments.length==3){
-        params = arguments[arguments.length-1];
+    if(callback && arguments.length == 4){
+        params = arguments[arguments.length - 2];
+    } else if(!callback && arguments.length == 3){
+        params = arguments[arguments.length - 1];
     }
 
     if(!callback) {
@@ -219,10 +217,10 @@ ENS.prototype.setOwner = function(name, addr) {
     }
 
     var params = {};
-    if (callback && arguments.length==4){
-        params = arguments[arguments.length-2];
-    } else if (!callback && arguments.length==3){
-        params = arguments[arguments.length-1];
+    if(callback && arguments.length == 4) {
+        params = arguments[arguments.length - 2];
+    } else if(!callback && arguments.length == 3) {
+        params = arguments[arguments.length - 1];
     }
 
     if(!callback) {
@@ -253,10 +251,10 @@ ENS.prototype.setSubnodeOwner = function(name, addr) {
     }
 
     var params = {};
-    if (callback && arguments.length==4){
-        params = arguments[arguments.length-2];
-    } else if (!callback && arguments.length==3){
-        params = arguments[arguments.length-1];
+    if (callback && arguments.length == 4) {
+        params = arguments[arguments.length - 2];
+    } else if (!callback && arguments.length == 3) {
+        params = arguments[arguments.length - 1];
     }
 
     if(!callback) {


### PR DESCRIPTION
The argument counting to find the `params` arg was only working when a callback function was present. 

