### PR TITLE
Externalize Network Map

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ var textEncoding = require('text-encoding');
 var TextDecoder = textEncoding.TextDecoder;
 var uts46 = require('idna-uts46');
 var _ = require('underscore');
+var registryAddresses = require('ethereum-ens-network-map');
 
 var registryInterface = [
   {
@@ -258,13 +259,6 @@ var resolverInterface = [
   }
 ];
 
-var registryAddresses = {
-  // Mainnet
-  "1": "0x314159265dd8dbb310642f98f50c066173c1259b",
-  // Ropsten
-  "3": "0x112234455c3a32fd11230c42e7bccd4a84e02010",
-}
-
 /**
  * @class
  */
@@ -279,7 +273,7 @@ function Resolver(ens, node, contract) {
         return Promise.promisifyAll(contract.at(address));
       });
     });
-    
+
     _.each(contract.abi, function(signature) {
         this[signature.name] = function() {
           var args = arguments;
@@ -326,7 +320,7 @@ function fromHex(x) {
   if(x.startsWith("0x")) {
     x = x.slice(2);
   }
-  
+
   var ret = new Uint8Array(x.length / 2);
   for(var i = 0; i < ret.length; i++) {
     ret[i] = parseInt(x.slice(i * 2, i * 2 + 2), 16);
@@ -369,7 +363,7 @@ Resolver.prototype.contract = function() {
   }.bind(this));
 };
 
-/** 
+/**
  * @class
  *
  * @description Provides an easy-to-use interface to the Ethereum Name Service.
@@ -529,7 +523,7 @@ ENS.prototype.owner = function(name, callback) {
 }
 
 /**
- * setOwner sets the owner of the specified name. Only the owner may call 
+ * setOwner sets the owner of the specified name. Only the owner may call
  * setResolver or setSubnodeOwner. The calling account must be the current
  * owner of the name in order for this call to succeed.
  * @param {string} name The name to update

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "bluebird": "^3.4.7",
     "crypto-js": "^3.1.6",
+    "ethereum-ens-network-map": "^1.0.0",
     "idna-uts46": "^1.0.1",
     "pako": "^1.0.4",
     "text-encoding": "^0.6.4",


### PR DESCRIPTION
I wrote [another ens client](https://github.com/flyswatter/ethjs-ens) because it was my way of learning ENS.

I want it to keep its network/registry map up to date automatically, so I moved [my network map to an external module](https://github.com/flyswatter/ethereum-ens-network-map), that we could maintain in a singular place, and benefit from together.

I'd gladly transfer the repository and npm control to ens/ethereum orgs for security purposes.