### PR TITLE
Update ethereumjs-testrpc dependency to use ganache-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   },
   "devDependencies": {
     "async": "^2.0.0",
+    "ganache-cli": "^6.1.0",
     "mocha": "^3.0.2",
-    "ethereumjs-testrpc": "^2.2.3",
-    "solc": "^0.4.9"
+    "solc": "0.4.9"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 var async = require('async');
 var fs = require('fs');
 var solc = require('solc');
-var TestRPC = require('ethereumjs-testrpc');
+var TestRPC = require('ganache-cli');
 var Web3 = require('web3');
 
 var web3 = new Web3();


### PR DESCRIPTION
ethereumjs-testrpc is deprecated. Fixing solc version at 0.4.9 fixes some compilation issues.
