### PR TITLE
pass provider to Web3

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ function ENS (provider, address, Web3js) {
   if (Web3js !== undefined) {
     Web3 = Web3js;
   }
-  if (!!/^0\./.exec(Web3.version || (new Web3()).version.api)) {
+  if (!!/^0\./.exec(Web3.version || (new Web3(provider)).version.api)) {
     return utils.construct(ENS_0, [provider, address]);
   } else {
     return utils.construct(ENS_1, [provider, address]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereum-ens",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "homepage": "https://github.com/Arachnid/ensjs#readme",
   "description": "Javascript bindings for the Ethereum Name Service",
   "main": "index.js",


### PR DESCRIPTION
When I upgraded ensjs on http://dnssec.ens.domains to ver 0.7.5, then I started getting `TypeError: Web3 is not a constructor` (the code to replicate is [here](https://github.com/makoto/ensjs#2-init-ens-with-web3-passed-as-argument--3-init-ens-with-old-web3)). This happens when the client app have `web3 1.0.0-beta.48` installed even though ensjs itself still uses  `web3 1.0.0-beta.34`. I am guessing some sort of global variable pollution where `Web3` is overwritten. I think this simple change fixes the issue.