### PR TITLE
remove text-encoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,8 +15,6 @@
 var namehash = require('eth-ens-namehash')
 var pako = require('pako');
 var Promise = require('bluebird');
-var textEncoding = require('text-encoding');
-var TextDecoder = textEncoding.TextDecoder;
 var _ = require('underscore');
 var Web3 = require('web3');
 var utils = require('./src/utils.js');
@@ -38,7 +36,7 @@ var registryAddresses = {
 
 var abiDecoders = {
   1: function(data) {
-    data  = new TextDecoder("utf-8").decode(data);
+    data  = utils.strFromUtf8Ab(data);
     return JSON.parse(data);
   },
   2: function(data) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereum-ens",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5514,11 +5514,6 @@
         "xtend": "^4.0.0"
       }
     },
-    "text-encoding": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
-    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -5652,11 +5647,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
       "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
-    },
-    "utf8": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
-      "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g="
     },
     "utf8-byte-length": {
       "version": "1.0.4",
@@ -6021,7 +6011,7 @@
         "lodash": "^4.17.11",
         "oboe": "2.1.4",
         "url-parse": "1.4.4",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
         "xhr2-cookies": "1.1.0"
       },
       "dependencies": {
@@ -6078,6 +6068,11 @@
           "version": "4.17.11",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
           "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "utf8": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
+          "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "eth-ens-namehash": "^2.0.0",
     "js-sha3": "^0.5.7",
     "pako": "^1.0.4",
-    "text-encoding": "^0.6.4",
     "underscore": "^1.8.3",
     "web3": "^1.0.0-beta.34"
   },

--- a/src/utils.js
+++ b/src/utils.js
@@ -28,5 +28,9 @@ module.exports = {
     }
     F.prototype = constructor.prototype;
     return new F();
+  },
+  strFromUtf8Ab: function(ab) {
+    // from https://stackoverflow.com/a/18722848
+    return decodeURIComponent(escape(String.fromCharCode.apply(null, ab)));
   }
 }


### PR DESCRIPTION
Solves issue #43 without another library. I didn't know how to run your tests but I tested it superficially at requirebin.com with the following code:
```js
var textEncoding = require('text-encoding');
var TextDecoder = textEncoding.TextDecoder;
var TextEncoder = textEncoding.TextEncoder;

function strFromUtf8Ab(ab) {
    return decodeURIComponent(escape(String.fromCharCode.apply(null, ab)));
}

let lorem = "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."

var foo = new TextEncoder().encode(lorem)
var bar = new TextDecoder("utf-8").decode(foo)

var goo = strFromUtf8Ab(foo)
console.log(bar === goo ? 'works' : 'fails')
```

Answer comes from https://stackoverflow.com/a/18722848

Should reduce your package by over half a MB