### PR TITLE
feat: remove useless code

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -196,10 +196,7 @@ class Resolver {
 
 class Name {
   constructor(options) {
-    const { name, ens, provider, signer, namehash: nh, resolver } = options
-    if (options.namehash) {
-      this.namehash = nh
-    }
+    const { name, ens, provider, signer, resolver } = options
     this.ens = ens
     this.ensWithSigner = this.ens.connect(signer)
     this.name = name


### PR DESCRIPTION
seems like the `namehash` in `options` is useless, as it is overridden below.

https://github.com/ensdomains/ensjs/pull/67/files#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L206