### PR TITLE
Link npm to github

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.1",
   "description": "ens.js v2",
   "main": "dist/index.js",
+  "repository": "ensdomains/ensjs",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Without this, there is no section on [the npm page](https://www.npmjs.com/package/@ensdomains/ensjs) which links to GitHub. 

This helps with project legitimacy as folks who find this package via npm can now see the code associated. In addition, tools like `ghub` will now work to direct users to this github: https://ghub.io/@ensdomains/ensjs