### PR TITLE
feat: support more coin types

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.4.4",
-    "@ensdomains/address-encoder": "^0.1.7",
+    "@ensdomains/address-encoder": "^0.2.16",
     "@ensdomains/ens": "0.4.5",
     "@ensdomains/resolver": "0.2.4",
     "content-hash": "^2.5.2",


### PR DESCRIPTION
```
const addr = await ens.name('bertho.eth').getAddress('BSC');
```

Doesn't work without this change, coin types have been added since.